### PR TITLE
Allow overriding $lato-font-path

### DIFF
--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -3,4 +3,4 @@
 // ------------------------------------------------------
 
 // Path to directory with Lato font files
-$lato-font-path: '../font';
+$lato-font-path: '../font' !default;


### PR DESCRIPTION
Without the `!default` keyword it is impossible to override the font path other then modifying original package. Which is something which you'd rather avoid if you use Bower ;)
