### PR TITLE
add a main section to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,10 @@
     "web",
     "font"
   ],
+  "main": [
+    "./css/lato.css",
+    "./font/*"
+  ],
   "licenses": [
     {
       "covers": "software",


### PR DESCRIPTION
If there is no main section in bower.json, the fonts will be missed by the [gulp-bower-files](https://www.npmjs.com/package/gulp-bower-files). 

gulp-bower-files is a part of the [gulp based yeoman web app generator](https://github.com/yeoman/generator-gulp-webapp), and it collect files in the bower_components folder. 

And as I checked the bower.json in [fontawesome](https://github.com/FortAwesome/Font-Awesome/blob/master/bower.json#L10), and [bootstrap-sass](https://github.com/twbs/bootstrap-sass/blob/master/bower.json#L12), they all got the fonts in the main section included in the main section. Therefore these fonts would be bulit, or copied, to the dist/fonts, while the lato fonts were missed.
